### PR TITLE
Fix “no allocations”

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,48 +1,72 @@
 {
-  "name": "go-allocations-vsix",
-  "version": "0.0.1",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "go-allocations-vsix",
-      "version": "0.0.1",
-      "devDependencies": {
-        "@types/node": "16.x",
-        "@types/vscode": "^1.74.0",
-        "typescript": "^4.9.4"
-      },
-      "engines": {
-        "vscode": "^1.74.0"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/vscode": {
-      "version": "1.104.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz",
-      "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
+    "name": "go-allocations-vsix",
+    "version": "0.2.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "go-allocations-vsix",
+            "version": "0.2.1",
+            "license": "MIT",
+            "dependencies": {
+                "shell-quote": "^1.8.3"
+            },
+            "devDependencies": {
+                "@types/node": "16.x",
+                "@types/shell-quote": "^1.7.5",
+                "@types/vscode": "^1.74.0",
+                "typescript": "^4.9.4"
+            },
+            "engines": {
+                "vscode": "^1.74.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "16.18.126",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/shell-quote": {
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+            "integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.104.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz",
+            "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -147,8 +147,12 @@
         "watch": "tsc -watch -p ./"
     },
     "devDependencies": {
-        "@types/vscode": "^1.74.0",
         "@types/node": "16.x",
+        "@types/shell-quote": "^1.7.5",
+        "@types/vscode": "^1.74.0",
         "typescript": "^4.9.4"
+    },
+    "dependencies": {
+        "shell-quote": "^1.8.3"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,8 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
                     }
                 }
 
-                // Simple semaphore: run 4 benchmarks concurrently
-                const concurrency = 4;
+                const concurrency = 2;
                 const semaphore = new Array(concurrency).fill(null);
 
                 const runBenchmark = async (benchmark: { packageItem: Item; benchmarkFunction: Item }) => {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -597,20 +597,18 @@ ROUTINE ======================== github.com/clipperhouse/uax29/v2.alloc in /User
                 throw new Error('Operation cancelled');
             }
 
-            const moduleName = benchmarkItem.parent.parent.moduleName;
-            const cmd = `go tool pprof -list=${moduleName} ${memprofilePath}`;
-
             // Use streaming approach for memory efficiency
-            const allocationItems = await new Promise<BenchmarkChildItem[]>((resolve, reject) => {
+            const results = await new Promise<BenchmarkChildItem[]>((resolve, reject) => {
                 const items: BenchmarkChildItem[] = [];
                 let currentFunction = '';
                 let currentFile = '';
                 let inFunction = false;
 
-                // Parse the command (e.g., "go tool pprof -list=moduleName memprofilePath")
-                const [command, ...args] = cmd.split(' ');
+                const moduleName = benchmarkItem.parent.parent.moduleName;
+                const cmd = 'go';
+                const args = ['tool', 'pprof', `-list=${moduleName}`, memprofilePath];
 
-                const child = spawn(command, args, {
+                const child = spawn(cmd, args, {
                     cwd: benchmarkItem.filePath,
                     signal,
                     stdio: ['ignore', 'pipe', 'pipe']
@@ -678,18 +676,14 @@ ROUTINE ======================== github.com/clipperhouse/uax29/v2.alloc in /User
                         reject(error);
                     }
                 });
-
-                child.stderr.on('data', (data) => {
-                    // Handle stderr if needed
-                });
             });
 
             // If no allocation data found, show a message
-            if (allocationItems.length === 0) {
-                allocationItems.push(this.noAllocationsItem);
+            if (results.length === 0) {
+                results.push(this.noAllocationsItem);
             }
 
-            return allocationItems;
+            return results;
         } catch (error) {
             console.error('Error parsing memory profile:', error);
             const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Some benchmarks were throwing a “no matches found for regexp” error, a result of `go pprof -list=<modulepath>`. This is returned when no user code (package) allocations made it into the memprofile.

This is not actually an error for our purposes. I believe it's simply a correct outcome of no allocations. So now we catch that error and look for that string.

Additionally, adjusted added -memprofilerate=1024*64 to the memprofile creation. As I understand it, this describes resolution/precision of allocations. “1024*64” indicates “only include allocs over 1024*64 bytes”. I believe the default is 512000, 512K. So now we might detect more allocations. Expect a small perf hit.

`-memprofilerate` was adjusted in an attempt to fix the error above. It did not fix the error, but seems desirable anyway.