### PR TITLE
Simplify runAllBenchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.2.1",
             "license": "MIT",
             "dependencies": {
+                "async-sema": "^3.1.1",
                 "shell-quote": "^1.8.3"
             },
             "devDependencies": {
@@ -40,6 +41,12 @@
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz",
             "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/async-sema": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+            "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
             "license": "MIT"
         },
         "node_modules/shell-quote": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         },
         "commands": [
             {
-                "command": "goAllocations.runAllBenchmarks",
+                "command": "goAllocations.runAllBenchmarksSimple",
                 "title": "Run all benchmarks and discover allocations",
                 "icon": "$(run-all)",
                 "when": "view == goAllocationsExplorer"
@@ -122,7 +122,7 @@
                     "group": "navigation"
                 },
                 {
-                    "command": "goAllocations.runAllBenchmarks",
+                    "command": "goAllocations.runAllBenchmarksSimple",
                     "when": "view == goAllocationsExplorer",
                     "group": "navigation"
                 },

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
         "typescript": "^4.9.4"
     },
     "dependencies": {
+        "async-sema": "^3.1.1",
         "shell-quote": "^1.8.3"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,125 +31,12 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     // Register commands
-    const runAllBenchmarks = vscode.commands.registerCommand('goAllocations.runAllBenchmarks',
+    const runAllBenchmarksSimple = vscode.commands.registerCommand('goAllocations.runAllBenchmarksSimple',
         async () => {
-            const signal = provider.abortSignal();
-
             try {
-                // Check if cancelled before starting
-                if (signal.aborted) {
-                    return;
-                }
-
-                // Get all root items (modules)
-                const rootItems = await provider.getChildren();
-
-                // Collect all benchmark functions first
-                const allBenchmarks: { packageItem: Item; benchmarkFunction: Item }[] = [];
-
-                for (const rootItem of rootItems) {
-                    if (signal.aborted) {
-                        return;
-                    }
-
-                    if (rootItem instanceof ModuleItem) {
-                        // Expand the module node
-                        await treeView.reveal(rootItem, { expand: true });
-
-                        // Get packages for this module
-                        const packageItems = await provider.getChildren(rootItem);
-
-                        for (const packageItem of packageItems) {
-                            if (signal.aborted) {
-                                return;
-                            }
-
-                            if (packageItem instanceof PackageItem) {
-                                // Expand the package node
-                                await treeView.reveal(packageItem, { expand: true });
-
-                                // Get benchmark functions for this package
-                                const benchmarkFunctions = await provider.getChildren(packageItem);
-
-                                // Collect all benchmark functions
-                                for (const benchmarkFunction of benchmarkFunctions) {
-                                    if (benchmarkFunction instanceof BenchmarkItem) {
-                                        allBenchmarks.push({ packageItem, benchmarkFunction });
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                const concurrency = 2;
-                const semaphore = new Array(concurrency).fill(null);
-
-                const runBenchmark = async (benchmark: { packageItem: Item; benchmarkFunction: Item }) => {
-                    // Check if cancelled before running this benchmark
-                    if (signal.aborted) {
-                        throw new Error('Operation cancelled');
-                    }
-
-                    // Expand the benchmark function node (treeView is guaranteed to exist at this point)
-                    await treeView.reveal(benchmark.benchmarkFunction, { expand: true });
-
-                    // Get allocation data for this benchmark (this will run the benchmark)
-                    // Pass the abort signal to the provider
-                    await provider.getChildren(benchmark.benchmarkFunction);
-                };
-
-                // Process benchmarks with concurrency control while preserving display order
-                const processBenchmarks = async () => {
-                    const allPromises = allBenchmarks.map(async (benchmark) => {
-                        // Wait for a semaphore slot
-                        let acquired = false;
-                        while (!acquired && !signal.aborted) {
-                            for (let i = 0; i < concurrency; i++) {
-                                if (semaphore[i] === null) {
-                                    semaphore[i] = benchmark;
-                                    acquired = true;
-                                    break;
-                                }
-                            }
-                            if (!acquired) {
-                                await new Promise(resolve => setTimeout(resolve, 250));
-                            }
-                        }
-
-                        if (signal.aborted) {
-                            return;
-                        }
-
-                        try {
-                            await runBenchmark(benchmark);
-                        } catch (error) {
-                            if (signal.aborted) {
-                                console.log('Benchmark cancelled:', benchmark.benchmarkFunction.label);
-                            } else {
-                                console.error('Benchmark error:', error);
-                            }
-                        } finally {
-                            // Release the semaphore slot
-                            const slotIndex = semaphore.indexOf(benchmark);
-                            if (slotIndex !== -1) {
-                                semaphore[slotIndex] = null;
-                            }
-                        }
-                    });
-
-                    // Wait for all benchmarks to complete or be cancelled
-                    await Promise.allSettled(allPromises);
-                };
-
-                await processBenchmarks();
-
-                if (signal.aborted) {
-                    vscode.window.showInformationMessage('Operation(s) cancelled');
-                }
+                await provider.runAllBenchmarksSimple(treeView);
             } catch (error) {
-                if (signal.aborted) {
-                    console.log('Operation cancelled');
+                if (provider.abortSignal().aborted) {
                     vscode.window.showInformationMessage('Operation(s) cancelled');
                 } else {
                     console.error('Error running all benchmarks:', error);
@@ -157,7 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
                 }
             }
         });
-    context.subscriptions.push(runAllBenchmarks);
+    context.subscriptions.push(runAllBenchmarksSimple);
 
     const stopAllBenchmarks = vscode.commands.registerCommand('goAllocations.stopAllBenchmarks',
         () => {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -764,7 +764,7 @@ ROUTINE ======================== github.com/clipperhouse/uax29/v2.alloc in /User
 
                                 if (benchmarkFunction instanceof BenchmarkItem) {
                                     try {
-                                        // Expand the benchmark function node - this will automatically call getChildren and run the benchmark
+                                        this.clearBenchmarkRunState(benchmarkFunction)
                                         await treeView.reveal(benchmarkFunction, { expand: true });
                                     } catch (error) {
                                         if (signal.aborted) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -754,21 +754,21 @@ ROUTINE ======================== github.com/clipperhouse/uax29/v2.alloc in /User
                             await treeView.reveal(packageItem, { expand: true });
 
                             // Get benchmark functions for this package
-                            const benchmarkFunctions = await this.getChildren(packageItem);
+                            const benchmarkItems = await this.getChildren(packageItem);
 
                             // Run benchmarks as we find them
-                            for (const benchmarkFunction of benchmarkFunctions) {
+                            for (const benchmarkItem of benchmarkItems) {
                                 if (signal.aborted) {
                                     return;
                                 }
 
-                                if (benchmarkFunction instanceof BenchmarkItem) {
+                                if (benchmarkItem instanceof BenchmarkItem) {
                                     try {
-                                        this.clearBenchmarkRunState(benchmarkFunction)
-                                        await treeView.reveal(benchmarkFunction, { expand: true });
+                                        this.clearBenchmarkRunState(benchmarkItem)
+                                        await treeView.reveal(benchmarkItem, { expand: true });
                                     } catch (error) {
                                         if (signal.aborted) {
-                                            console.log('Benchmark cancelled:', benchmarkFunction.label);
+                                            console.log('Benchmark cancelled:', benchmarkItem.label);
                                         } else {
                                             console.error('Benchmark error:', error);
                                         }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -48,7 +48,6 @@ export class PackageItem extends vscode.TreeItem {
 export class BenchmarkItem extends vscode.TreeItem {
     public readonly filePath: string;
     public readonly contextValue: 'benchmarkFunction' = 'benchmarkFunction';
-    public hasBeenRun: boolean = false;
     public readonly parent: PackageItem;
 
     constructor(
@@ -189,7 +188,6 @@ export class Provider implements vscode.TreeDataProvider<Item> {
 
 
     clearBenchmarkRunState(item: BenchmarkItem): void {
-        item.hasBeenRun = false;
         this._onDidChangeTreeData.fire(item);
     }
 
@@ -289,7 +287,6 @@ export class Provider implements vscode.TreeDataProvider<Item> {
 
         if (element instanceof BenchmarkItem) {
             const allocationData = await this.getAllocationData(element);
-            element.hasBeenRun = true;
             return allocationData;
         }
 


### PR DESCRIPTION
The existing semaphore was kludgy. This PR:

- First, tears out that existing semaphore, resets to simple synchronous iteration over all benchmarks. Moves it to `Provider`.
- Then, import a proper semaphore library and use that.

Getting the concurrency working turned out to be finicky. tl;dr stuff about `Thenable` vs `Promise` on `treeView.reveal`. Copilot figured it out, Cursor struggled.

`hasBeenRun` wasn’t serving any purpose, the `treeView` keeps that state.