### PR TITLE
Encapsulate gathering of children items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "go-allocations-vsix",
-    "version": "0.3.2",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "go-allocations-vsix",
-            "version": "0.3.2",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
                 "async-sema": "^3.1.1",
                 "shell-quote": "^1.8.3"
             },
             "devDependencies": {
-                "@types/node": "16.x",
+                "@types/node": "20.x",
                 "@types/shell-quote": "^1.7.5",
                 "@types/vscode": "^1.74.0",
                 "esbuild": "^0.25.10",
@@ -466,11 +466,14 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "16.18.126",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "version": "20.19.17",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+            "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
         },
         "node_modules/@types/shell-quote": {
             "version": "1.7.5",
@@ -559,6 +562,13 @@
             "engines": {
                 "node": ">=4.2.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         "typecheck:watch": "tsc --noEmit --watch"
     },
     "devDependencies": {
-        "@types/node": "16.x",
+        "@types/node": "20.x",
         "@types/shell-quote": "^1.7.5",
         "@types/vscode": "^1.74.0",
         "esbuild": "^0.25.10",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -128,7 +128,7 @@ export class BenchmarkItem extends vscode.TreeItem {
             const memprofilerate = 1024 * 64; // 64K
 
             // Use shell-quote to safely escape the benchmark name
-            const cmd = `go test -bench=^${escapedBenchmarkName}$ -memprofile=${memprofilePath} -run=^$ -gcflags="all=-N -l" -memprofilerate=${memprofilerate}`;
+            const cmd = `go test -bench=^${escapedBenchmarkName}$ -memprofile=${memprofilePath} -run=^$ -memprofilerate=${memprofilerate}`;
 
             try {
                 const { stdout, stderr } = await execAsync(


### PR DESCRIPTION
Many methods were on the `Provider` class, too many. Move several of them into the `*Item` types. 

For example, `AllocationItem`s are now gathered by a method of `BenchmarkItem`; `BenchmarkItem`s are loaded by `PackageItem`. And up the hierarchy — types load their children: `ModuleItem` → `PackageItem` → `BenchmarkItem` → `AllocationItem`

Also, unrelated to the above, removed `gcflags` on the benchmarks runs & memprofile. Original theory was to improve accuracy, by disabling inlining and optimizations. I am not convinced that’s a good theory.