### PR TITLE
Use goals to discover benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Automatically run benchmarks when opening a Go workspace"
+                },
+                "goAllocations.useGopls": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Use gopls (Go language server) for faster package and benchmark discovery"
                 }
             }
         },
@@ -111,6 +116,11 @@
             {
                 "command": "goAllocations.test",
                 "title": "Test Extension",
+                "when": "true"
+            },
+            {
+                "command": "goAllocations.testDiscoveryPerformance",
+                "title": "Test Discovery Performance",
                 "when": "true"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
     "name": "go-allocations-vsix",
     "displayName": "Go Allocations Explorer",
-    "description": "An extension that helps locate Go allocations, using your benchmarks.",
+    "description": "An extension that helps locate Go allocations, using your benchmarks. Requires the Go extension.",
     "icon": "images/memory.goblue.png",
     "version": "0.3.1",
     "publisher": "Clipperhouse",
     "engines": {
         "vscode": "^1.74.0"
     },
+    "extensionDependencies": [
+        "golang.go"
+    ],
     "categories": [
         "Debuggers",
         "Testing"
@@ -62,11 +65,6 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Automatically run benchmarks when opening a Go workspace"
-                },
-                "goAllocations.useGopls": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Use gopls (Go language server) for faster package and benchmark discovery"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { Provider, Item, ModuleItem, PackageItem, BenchmarkItem, AllocationItem } from './provider';
 
 export function activate(context: vscode.ExtensionContext) {
-    const provider = new Provider();
+    console.log('Go Allocations Explorer: Activating...');    const provider = new Provider();
 
     let options: vscode.TreeViewOptions<Item> = {
         treeDataProvider: provider,
@@ -78,43 +78,43 @@ export function activate(context: vscode.ExtensionContext) {
             const output = vscode.window.createOutputChannel('Go Allocations Performance Test');
             output.clear();
             output.show();
-            
+
             try {
                 output.appendLine('=== Discovery Performance Test ===\n');
-                
+
                 // Test gopls method
                 output.appendLine('Testing gopls-based discovery...');
                 const goplsStartTime = Date.now();
-                
+
                 const testProvider = new Provider();
                 const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
                 if (!workspaceFolder) {
                     output.appendLine('No workspace folder found');
                     return;
                 }
-                
+
                 await (testProvider as any).loadPackagesFromWorkspaceUsingGopls(workspaceFolder.uri.fsPath);
                 const goplsTime = Date.now() - goplsStartTime;
                 output.appendLine(`Gopls discovery completed in ${goplsTime}ms\n`);
-                
+
                 // Test traditional method
                 output.appendLine('Testing traditional discovery...');
                 const traditionalStartTime = Date.now();
-                
+
                 const testProvider2 = new Provider();
                 await (testProvider2 as any).loadPackagesFromWorkspace(workspaceFolder.uri.fsPath);
                 const traditionalTime = Date.now() - traditionalStartTime;
                 output.appendLine(`Traditional discovery completed in ${traditionalTime}ms\n`);
-                
+
                 // Compare results
                 const speedup = traditionalTime / goplsTime;
                 output.appendLine('=== Results ===');
                 output.appendLine(`Gopls method: ${goplsTime}ms`);
                 output.appendLine(`Traditional method: ${traditionalTime}ms`);
                 output.appendLine(`Speedup: ${speedup.toFixed(2)}x ${speedup > 1 ? 'faster' : 'slower'}`);
-                
+
                 vscode.window.showInformationMessage(`Discovery test completed. Gopls is ${speedup.toFixed(2)}x ${speedup > 1 ? 'faster' : 'slower'} than traditional method.`);
-                
+
             } catch (error) {
                 output.appendLine(`Error during performance test: ${error}`);
                 console.error('Performance test error:', error);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -278,7 +278,6 @@ export class Provider implements vscode.TreeDataProvider<Item> {
 
         try {
             console.log('Using gopls for package and benchmark discovery');
-            const discoveryStartTime = Date.now();
 
             for (const workspaceFolder of vscode.workspace.workspaceFolders) {
                 if (signal.aborted) {
@@ -296,8 +295,7 @@ export class Provider implements vscode.TreeDataProvider<Item> {
                 }
             }
 
-            const totalDiscoveryTime = Date.now() - discoveryStartTime;
-            console.log(`Discovery completed in ${totalDiscoveryTime}ms using gopls`);
+            console.log('Discovery completed using gopls');
         } catch (error) {
             if (signal.aborted) {
                 console.log('Package loading cancelled');
@@ -352,13 +350,11 @@ export class Provider implements vscode.TreeDataProvider<Item> {
 
             // Use VS Code's workspace symbol provider to find benchmark functions
             console.log('Discovering benchmarks using gopls...');
-            const startTime = Date.now();
             const symbols = await vscode.commands.executeCommand(
                 'vscode.executeWorkspaceSymbolProvider',
                 'Benchmark'
             ) as vscode.SymbolInformation[];
-            const goplsTime = Date.now() - startTime;
-            console.log(`Gopls symbol query took ${goplsTime}ms, found ${symbols?.length || 0} total symbols`);
+            console.log(`Found ${symbols?.length || 0} total symbols`);
 
             if (signal.aborted) {
                 throw new Error('Operation cancelled');

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -358,14 +358,6 @@ export class Provider implements vscode.TreeDataProvider<Item> {
                 throw new Error('Operation cancelled');
             }
 
-            // Ensure Go extension is available and active (for gopls)
-            const goExtension = vscode.extensions.getExtension('golang.go');
-            if (goExtension && !goExtension.isActive) {
-                console.log('Go extension not active, activating...');
-                await goExtension.activate();
-                console.log('Go extension activated');
-            }
-
             const rootPath = workspaceFolder.uri.fsPath;
 
             // Get the module name for this workspace (still need go list for this)


### PR DESCRIPTION
Current implementation is a bunch of call to `go list`. It’s slow, though. 

gopls, via VS Code internal calls, locates the benchmark function symbols quite fast.