### PR TITLE
Renames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ When I ask for a new feature, focus on the smallest, simplest version first. Onl
 implement the "happy path" to start. After that, suggest edge cases and error
 paths. Perhaps add comments indicating a TODO for handling those cases.
 
+## Data structures and integrity
+
 Avoid creating two sources of truth. There are two main data structures:
 
 - The module cache is the source of truth for the module structure.
@@ -19,13 +21,17 @@ Avoid creating two sources of truth. There are two main data structures:
 You might think of it as analogous to an MVC pattern. The model is the module
 cache, the view is the TreeView, and the controller is the provider.
 
+Use types to help detect errors.
+
 Prefer to throw an error when something unexpected happens. It probably
 indicates a bug, or a violation of an invariant. Avoid things called
 "ensure", that's a code smell.
 
-Use types to help detect errors.
+## Pull requests and code reviews
 
 When I ask you to "review this PR", use the gh CLI tool to get information
-about the pull request. When I ask you to publish your review summary to
-the PR, use the gh CLI tool to do so, and clearly identify who you are
-(Cursor) as well as what LLM model you are using.
+about the pull request, based on the current local git branch.
+
+When I ask you to publish your review summary to the PR, use the gh CLI tool
+to do so, and **clearly identify** who you are (Cursor), that this was an
+automated review, and what LLM model you are using.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         },
         "commands": [
             {
-                "command": "goAllocations.runAllBenchmarksSimple",
+                "command": "goAllocations.runAllBenchmarks",
                 "title": "Run all benchmarks and discover allocations",
                 "icon": "$(run-all)",
                 "when": "view == goAllocationsExplorer"
@@ -132,7 +132,7 @@
                     "group": "navigation"
                 },
                 {
-                    "command": "goAllocations.runAllBenchmarksSimple",
+                    "command": "goAllocations.runAllBenchmarks",
                     "when": "view == goAllocationsExplorer",
                     "group": "navigation"
                 },

--- a/src/codelens.ts
+++ b/src/codelens.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export class CodeLensProvider implements vscode.CodeLensProvider {
+    private readonly benchRegex = /^\s*func\s+(Benchmark[A-Za-z0-9_]+)\s*\(b\s*\*testing\.B\)/;
+    private onDidChangeCodeLensesEmitter = new vscode.EventEmitter<void>();
+    public readonly onDidChangeCodeLenses: vscode.Event<void> = this.onDidChangeCodeLensesEmitter.event;
+
+    constructor() { }
+
+    provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
+        // Only add to _test.go files
+        if (!document.fileName.endsWith('_test.go')) return [];
+
+        const lenses: vscode.CodeLens[] = [];
+        for (let i = 0; i < document.lineCount; i++) {
+            const line = document.lineAt(i);
+            const m = line.text.match(this.benchRegex);
+            if (m) {
+                const benchName = m[1];
+                // Unfortunately, there is no official API to control CodeLens ordering across providers.
+                // The best we can do is use the same range as the Go extension and hope VS Code's merge
+                // algorithm places ours in a reasonable position.
+                const range = new vscode.Range(i, 0, i, line.text.length);
+                const packageDir = path.dirname(document.uri.fsPath);
+                const cmd: vscode.Command = {
+                    command: 'goAllocations.runBenchmarkFromEditor',
+                    title: 'find allocations',
+                    arguments: [{ packageDir, benchmarkName: benchName }]
+                };
+                lenses.push(new vscode.CodeLens(range, cmd));
+            }
+        }
+        return lenses;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
-import { Provider, Item, BenchmarkItem, AllocationItem } from './provider';
+import { TreeDataProvider, Item, BenchmarkItem, AllocationItem } from './treedata';
+import { CodeLensProvider } from './codelens';
 
 export async function activate(context: vscode.ExtensionContext) {
-    const provider = new Provider();
+    const treeData = new TreeDataProvider();
 
     let options: vscode.TreeViewOptions<Item> = {
-        treeDataProvider: provider,
+        treeDataProvider: treeData,
         showCollapseAll: true
     }
     let treeView = vscode.window.createTreeView<Item>('goAllocationsExplorer', options);
@@ -35,9 +35,9 @@ export async function activate(context: vscode.ExtensionContext) {
     const runAllBenchmarksSimple = vscode.commands.registerCommand('goAllocations.runAllBenchmarksSimple',
         async () => {
             try {
-                await provider.runAllBenchmarksSimple(treeView);
+                await treeData.runAllBenchmarksSimple(treeView);
             } catch (error) {
-                if (provider.abortSignal().aborted) {
+                if (treeData.abortSignal().aborted) {
                     vscode.window.showInformationMessage('Operation(s) cancelled');
                 } else {
                     console.error('Error running all benchmarks:', error);
@@ -50,16 +50,16 @@ export async function activate(context: vscode.ExtensionContext) {
     const stopAllBenchmarks = vscode.commands.registerCommand('goAllocations.stopAllBenchmarks',
         () => {
             vscode.window.showInformationMessage('Cancelling operation(s). Go processes may take a moment to terminate.');
-            provider.cancelAll();
+            treeData.cancelAll();
         });
     context.subscriptions.push(stopAllBenchmarks);
 
     const runSingleBenchmark = vscode.commands.registerCommand('goAllocations.runSingleBenchmark',
         async (benchmarkItem: BenchmarkItem) => {
-            const signal = provider.abortSignal();
+            const signal = treeData.abortSignal();
 
             try {
-                provider.clearBenchmarkRunState(benchmarkItem);
+                treeData.clearBenchmarkRunState(benchmarkItem);
                 await treeView.reveal(benchmarkItem, { expand: true });
             } catch (error) {
                 if (signal.aborted) {
@@ -75,14 +75,11 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(runSingleBenchmark);
 
     const refresh = vscode.commands.registerCommand('goAllocations.refresh',
-        () => provider.refresh());
+        () => treeData.refresh());
     context.subscriptions.push(refresh);
 
-    // Register a CodeLens provider for Go benchmark functions
-    // Note: CodeLens ordering from multiple providers is determined by the range position.
-    // To appear after the Go extension's lenses, we use a range that starts slightly to the right.
-    const codeLensProvider = vscode.languages.registerCodeLensProvider({ language: 'go', scheme: 'file' }, new GoBenchmarkCodeLensProvider());
-    context.subscriptions.push(codeLensProvider);
+    const codeLens = vscode.languages.registerCodeLensProvider({ language: 'go', scheme: 'file' }, new CodeLensProvider());
+    context.subscriptions.push(codeLens);
 
     // Command invoked by CodeLens in editor to run a specific benchmark
     const runBenchmarkFromEditor = vscode.commands.registerCommand('goAllocations.runBenchmarkFromEditor', async (args: { packageDir: string; benchmarkName: string }) => {
@@ -93,8 +90,8 @@ export async function activate(context: vscode.ExtensionContext) {
             // Focus the Go Allocations Explorer view
             await vscode.commands.executeCommand('workbench.view.extension.goAllocations');
 
-            const benchmarkItem = await provider.findBenchmark(args.packageDir, args.benchmarkName);
-            provider.clearBenchmarkRunState(benchmarkItem);
+            const benchmarkItem = await treeData.findBenchmark(args.packageDir, args.benchmarkName);
+            treeData.clearBenchmarkRunState(benchmarkItem);
             await treeView.reveal(benchmarkItem, { expand: true, select: true });
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -105,37 +102,3 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() { }
-
-class GoBenchmarkCodeLensProvider implements vscode.CodeLensProvider {
-    private readonly benchRegex = /^\s*func\s+(Benchmark[A-Za-z0-9_]+)\s*\(b\s*\*testing\.B\)/;
-    private onDidChangeCodeLensesEmitter = new vscode.EventEmitter<void>();
-    public readonly onDidChangeCodeLenses: vscode.Event<void> = this.onDidChangeCodeLensesEmitter.event;
-
-    constructor() { }
-
-    provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
-        // Only add to _test.go files
-        if (!document.fileName.endsWith('_test.go')) return [];
-
-        const lenses: vscode.CodeLens[] = [];
-        for (let i = 0; i < document.lineCount; i++) {
-            const line = document.lineAt(i);
-            const m = line.text.match(this.benchRegex);
-            if (m) {
-                const benchName = m[1];
-                // Unfortunately, there is no official API to control CodeLens ordering across providers.
-                // The best we can do is use the same range as the Go extension and hope VS Code's merge
-                // algorithm places ours in a reasonable position.
-                const range = new vscode.Range(i, 0, i, line.text.length);
-                const packageDir = path.dirname(document.uri.fsPath);
-                const cmd: vscode.Command = {
-                    command: 'goAllocations.runBenchmarkFromEditor',
-                    title: 'find allocations',
-                    arguments: [{ packageDir, benchmarkName: benchName }]
-                };
-                lenses.push(new vscode.CodeLens(range, cmd));
-            }
-        }
-        return lenses;
-    }
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,10 +32,10 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     // Register commands
-    const runAllBenchmarksSimple = vscode.commands.registerCommand('goAllocations.runAllBenchmarksSimple',
+    const runAllBenchmarks = vscode.commands.registerCommand('goAllocations.runAllBenchmarks',
         async () => {
             try {
-                await treeData.runAllBenchmarksSimple(treeView);
+                await treeData.runAllBenchmarks(treeView);
             } catch (error) {
                 if (treeData.abortSignal().aborted) {
                     vscode.window.showInformationMessage('Operation(s) cancelled');
@@ -45,7 +45,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 }
             }
         });
-    context.subscriptions.push(runAllBenchmarksSimple);
+    context.subscriptions.push(runAllBenchmarks);
 
     const stopAllBenchmarks = vscode.commands.registerCommand('goAllocations.stopAllBenchmarks',
         () => {

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -475,7 +475,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
             // If not loaded, start loading
             if (!this.loadingPromise) {
                 // Start loading in the background and store the promise
-                this.loadingPromise = this.loadPackages().catch(error => {
+                this.loadingPromise = this.loadModules().catch(error => {
                     console.error('Error loading packages:', error);
                 });
             }
@@ -506,7 +506,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         return Promise.resolve([]);
     }
 
-    private async loadPackages(): Promise<void> {
+    private async loadModules(): Promise<void> {
         const signal = this.abortSignal();
 
         if (!vscode.workspace.workspaceFolders) {
@@ -549,7 +549,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
                 }
 
                 try {
-                    await this.loadPackagesFromWorkspace(workspaceFolder, allBenchmarkSymbols);
+                    await this.loadModulesInWorkspace(workspaceFolder, allBenchmarkSymbols);
                 } catch (error) {
                     if (signal.aborted) {
                         throw error;
@@ -571,10 +571,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
     }
 
     private readonly benchmarkNameRegex = /^Benchmark[A-Z_]/;
-    /**
-     * Load packages and benchmarks using workspace symbol search
-     */
-    private async loadPackagesFromWorkspace(
+    private async loadModulesInWorkspace(
         workspaceFolder: vscode.WorkspaceFolder,
         allBenchmarkSymbols: Array<{ name: string; fileUri: vscode.Uri }>
     ): Promise<void> {
@@ -658,9 +655,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         }
     }
 
-    /**
-     * Helper method to determine package name from directory path
-     */
     private async getPackageNameFromPath(packageDir: string, rootPath: string): Promise<string> {
         const relativePath = path.relative(rootPath, packageDir);
         if (relativePath === '') {

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -130,7 +130,7 @@ interface ModuleCache {
     packages: { name: string; path: string; benchmarks: string[] }[]
 }
 
-export class Provider implements vscode.TreeDataProvider<Item> {
+export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
     public _onDidChangeTreeData: vscode.EventEmitter<Item | undefined | null | void> = new vscode.EventEmitter<Item | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<Item | undefined | null | void> = this._onDidChangeTreeData.event;
 

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -12,6 +12,21 @@ const execAsync = promisify(exec);
 
 export type Item = ModuleItem | PackageItem | BenchmarkItem | InformationItem | AllocationItem;
 
+export class InformationItem extends vscode.TreeItem {
+    public readonly contextValue: 'information' = 'information';
+
+    constructor(
+        label: string,
+        iconType: 'error' | 'info' | 'none' = 'none'
+    ) {
+        super(label, vscode.TreeItemCollapsibleState.None);
+
+        if (iconType !== 'none') {
+            this.iconPath = new vscode.ThemeIcon(iconType);
+        }
+    }
+}
+
 export class ModuleItem extends vscode.TreeItem {
     public readonly moduleName: string;
     public readonly modulePath: string;
@@ -45,6 +60,10 @@ export class PackageItem extends vscode.TreeItem {
     }
 }
 
+const noAllocationsItem = new InformationItem('No allocations found', 'info');
+const routineRegex = /^ROUTINE\s*=+\s*(.+?)\s+in\s+(.+)$/;
+const lineRegex = /^\s*(\d+(?:\.\d+)?[KMGT]?B)?\s*(\d+(?:\.\d+)?[KMGT]?B)?\s*(\d+):\s*(.+)$/;
+
 export class BenchmarkItem extends vscode.TreeItem {
     public readonly contextValue: 'benchmarkFunction' = 'benchmarkFunction';
     public readonly parent: PackageItem;
@@ -63,24 +82,205 @@ export class BenchmarkItem extends vscode.TreeItem {
     get filePath(): string {
         return this.parent.filePath;
     }
+
+    async getChildren(signal: AbortSignal): Promise<BenchmarkChildItem[]> {
+        if (!this.filePath) {
+            return [];
+        }
+
+        try {
+            // Check if operation is cancelled before starting
+            if (signal.aborted) {
+                throw new Error('Operation cancelled');
+            }
+
+            // Create unique temporary file for memory profile
+            const tempDir = os.tmpdir();
+            const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}-${process.pid}`;
+            const memprofilePath = path.join(tempDir, `go-allocations-memprofile-${uniqueId}.pb.gz`);
+            const benchmarkName = typeof this.label === 'string' ? this.label : this.label?.label || '';
+            const escapedBenchmarkName = quote([benchmarkName]);
+            const memprofilerate = 1024 * 64; // 64K
+
+            const cmd = `go test -bench=^${escapedBenchmarkName}$ -memprofile=${memprofilePath} -run=^$ -memprofilerate=${memprofilerate}`;
+
+            try {
+                const { stdout, stderr } = await execAsync(
+                    cmd,
+                    {
+                        cwd: this.filePath,
+                        signal: signal
+                    }
+                );
+
+                if (stderr) {
+                    console.error('Benchmark stderr:', stderr);
+                }
+
+                // Check if operation was cancelled after benchmark completion
+                if (signal.aborted) {
+                    throw new Error('Operation cancelled');
+                }
+
+                // Parse the memory profile using pprof
+                const allocationData = await this.parseMemoryProfile(memprofilePath, signal);
+
+                return allocationData;
+            } finally {
+                // Clean up the memory profile file
+                try {
+                    await fs.promises.unlink(memprofilePath);
+                } catch (cleanupError) {
+                    console.warn('Could not clean up memory profile file:', cleanupError);
+                }
+            }
+        } catch (error) {
+            console.error('Error getting allocation data:', error);
+            const msg = error instanceof Error ? error.message : String(error);
+            return [
+                new InformationItem(
+                    `${msg}`,
+                    'error'
+                )
+            ];
+        }
+    }
+
+    private async parseMemoryProfile(memprofilePath: string, signal: AbortSignal): Promise<BenchmarkChildItem[]> {
+        try {
+            // Check if operation was cancelled before parsing
+            if (signal.aborted) {
+                throw new Error('Operation cancelled');
+            }
+
+            // Use streaming approach for memory efficiency
+            const results = await new Promise<BenchmarkChildItem[]>((resolve, reject) => {
+                const items: BenchmarkChildItem[] = [];
+                let currentFunction = '';
+                let currentFile = '';
+                let inFunction = false;
+                let stderr = '';
+
+                const moduleName = this.parent.parent.moduleName;
+                const cmd = 'go';
+                const args = ['tool', 'pprof', `-list=${moduleName}`, memprofilePath];
+
+                const child = spawn(cmd, args, {
+                    cwd: this.filePath,
+                    signal,
+                    stdio: ['ignore', 'pipe', 'pipe']
+                });
+
+                const rl = readline.createInterface({
+                    input: child.stdout,
+                    crlfDelay: Infinity
+                });
+
+                // Capture stderr output
+                child.stderr?.on('data', (data) => {
+                    stderr += data.toString();
+                });
+
+                rl.on('line', (line) => {
+                    const trimmedLine = line.trim();
+
+                    // Check if this is a function header
+                    const functionMatch = trimmedLine.match(routineRegex);
+                    if (functionMatch) {
+                        currentFunction = functionMatch[1];
+                        currentFile = functionMatch[2];
+                        inFunction = true;
+                        return;
+                    }
+
+                    // Check if we're in a function and this is a line with allocation data
+                    if (inFunction && trimmedLine && !trimmedLine.includes('Total:') && !trimmedLine.includes('ROUTINE')) {
+                        const lineMatch = trimmedLine.match(lineRegex);
+                        if (lineMatch) {
+                            const flatBytes = lineMatch[1] || '0B';
+                            const cumulativeBytes = lineMatch[2] || '0B';
+                            const lineNumber = parseInt(lineMatch[3]);
+                            const codeLine = lineMatch[4];
+
+                            if (lineNumber > 0 && (flatBytes !== '0B' || cumulativeBytes !== '0B')) {
+                                const functionName = this.shortFunctionName(currentFunction);
+
+                                const allocationItem = new AllocationItem(
+                                    `${codeLine.trim()}`,
+                                    currentFile,
+                                    lineNumber,
+                                    {
+                                        flatBytes: flatBytes,
+                                        cumulativeBytes: cumulativeBytes,
+                                        functionName: functionName
+                                    }
+                                );
+                                items.push(allocationItem);
+                            }
+                        }
+                    }
+
+                    // Reset when we hit an empty line or new function
+                    if (trimmedLine === '' || trimmedLine.includes('ROUTINE')) {
+                        inFunction = false;
+                    }
+                });
+
+                rl.on('close', () => {
+                    resolve(items);
+                });
+
+                // Handle process spawn errors (e.g., command not found)
+                child.on('error', (error) => {
+                    reject(error);
+                });
+
+                child.on('close', (code) => {
+                    if (stderr.includes('no matches found for regexp')) {
+                        resolve([noAllocationsItem]);
+                        return;
+                    }
+
+                    // If process exited with non-zero code and we have stderr, treat as error
+                    if (code !== 0 && stderr.trim()) {
+                        reject(new Error(`pprof exit code ${code}: ${stderr.trim()}`));
+                        return;
+                    }
+
+                    // If we get here, the process completed successfully
+                    // The readline interface will handle resolving with the parsed items
+                });
+            });
+
+            // If no allocation data found, show a message
+            if (results.length === 0) {
+                results.push(noAllocationsItem);
+            }
+
+            return results;
+        } catch (error) {
+            console.error('Error parsing memory profile:', error);
+            const msg = error instanceof Error ? error.message : String(error);
+            return [
+                new InformationItem(
+                    `${msg}`,
+                    'error'
+                )
+            ];
+        }
+    }
+
+    // Display helper: last path segment after '/', then after first '.'
+    private shortFunctionName = (fullName: string): string => {
+        const slash = fullName.lastIndexOf('/');
+        const afterSlash = slash >= 0 ? fullName.slice(slash + 1) : fullName;
+        const firstDot = afterSlash.indexOf('.');
+        return firstDot >= 0 ? afterSlash.slice(firstDot + 1) : afterSlash;
+    }
 }
 
 export type BenchmarkChildItem = InformationItem | AllocationItem;
 
-export class InformationItem extends vscode.TreeItem {
-    public readonly contextValue: 'information' = 'information';
-
-    constructor(
-        label: string,
-        iconType: 'error' | 'info' | 'none' = 'none'
-    ) {
-        super(label, vscode.TreeItemCollapsibleState.None);
-
-        if (iconType !== 'none') {
-            this.iconPath = new vscode.ThemeIcon(iconType);
-        }
-    }
-}
 
 export class AllocationItem extends vscode.TreeItem {
     public readonly filePath: string;
@@ -259,8 +459,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         }
 
         if (element instanceof BenchmarkItem) {
-            const allocationData = await this.getAllocationData(element);
-            return allocationData;
+            return await element.getChildren(this.abortSignal());
         }
 
         return Promise.resolve([]);
@@ -485,245 +684,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         }
 
         return benchmarks;
-    }
-
-    async getAllocationData(benchmarkItem: BenchmarkItem): Promise<BenchmarkChildItem[]> {
-        const signal = this.abortSignal();
-
-        if (!benchmarkItem.filePath) {
-            return [];
-        }
-
-        try {
-            // Check if operation is cancelled before starting
-            if (signal.aborted) {
-                throw new Error('Operation cancelled');
-            }
-
-            // Create unique temporary file for memory profile
-            const tempDir = os.tmpdir();
-            const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}-${process.pid}`;
-            const memprofilePath = path.join(tempDir, `go-allocations-memprofile-${uniqueId}.pb.gz`);
-            const benchmarkName = typeof benchmarkItem.label === 'string' ? benchmarkItem.label : benchmarkItem.label?.label || '';
-            const escapedBenchmarkName = quote([benchmarkName]);
-            const memprofilerate = 1024 * 64; // 64K
-
-            // Use shell-quote to safely escape the benchmark name
-            const cmd = `go test -bench=^${escapedBenchmarkName}$ -memprofile=${memprofilePath} -run=^$ -memprofilerate=${memprofilerate}`;
-
-            try {
-                const { stdout, stderr } = await execAsync(
-                    cmd,
-                    {
-                        cwd: benchmarkItem.filePath,
-                        signal: signal
-                    }
-                );
-
-                if (stderr) {
-                    console.error('Benchmark stderr:', stderr);
-                }
-
-                // Check if operation was cancelled after benchmark completion
-                if (signal.aborted) {
-                    throw new Error('Operation cancelled');
-                }
-
-                // Parse the memory profile using pprof
-                const allocationData = await this.parseMemoryProfile(memprofilePath, benchmarkItem);
-
-                return allocationData;
-            } finally {
-                // Clean up the memory profile file
-                try {
-                    await fs.promises.unlink(memprofilePath);
-                } catch (cleanupError) {
-                    console.warn('Could not clean up memory profile file:', cleanupError);
-                }
-            }
-        } catch (error) {
-            console.error('Error getting allocation data:', error);
-            const msg = error instanceof Error ? error.message : String(error);
-            return [
-                new InformationItem(
-                    `${msg}`,
-                    'error'
-                )
-            ];
-        }
-    }
-
-    // Display helper: last path segment after '/', then after first '.'
-    private shortFunctionName = (fullName: string): string => {
-        const slash = fullName.lastIndexOf('/');
-        const afterSlash = slash >= 0 ? fullName.slice(slash + 1) : fullName;
-        const firstDot = afterSlash.indexOf('.');
-        return firstDot >= 0 ? afterSlash.slice(firstDot + 1) : afterSlash;
-    }
-
-    private readonly noAllocationsItem = new InformationItem('No allocations found', 'info');
-    private readonly routineRegex = /^ROUTINE\s*=+\s*(.+?)\s+in\s+(.+)$/;
-    private readonly lineRegex = /^\s*(\d+(?:\.\d+)?[KMGT]?B)?\s*(\d+(?:\.\d+)?[KMGT]?B)?\s*(\d+):\s*(.+)$/;
-
-    private async parseMemoryProfile(memprofilePath: string, benchmarkItem: BenchmarkItem): Promise<BenchmarkChildItem[]> {
-        /*
-        Example pprof -list output:
-
-ROUTINE ======================== github.com/clipperhouse/uax29/v2.BenchmarkString in /Users/msherman/Documents/code/src/github.com/clipperhouse/uax29/uax29_test.go
-     0     3.77GB (flat, cum) 99.92% of Total
-     .          .     13:func BenchmarkString(b *testing.B) {
-     .          .     14:	for i := 0; i < b.N; i++ {
-     .     3.77GB     15:		alloc()
-     .          .     16:	}
-     .          .     17:}
-ROUTINE ======================== github.com/clipperhouse/uax29/v2.alloc in /Users/msherman/Documents/code/src/github.com/clipperhouse/uax29/uax29_test.go
-3.77GB     3.77GB (flat, cum) 99.92% of Total
-     .          .      9:func alloc() {
-3.77GB     3.77GB     10:	_ = "updated nine times. Hello, world! こんにちは 안녕하세요 مرحبا" + strconv.Itoa(rand.Intn(20))
-     .          .     11:}
-     .          .     12:
-     .          .     13:func BenchmarkString(b *testing.B) {
-     .          .     14:	for i := 0; i < b.N; i++ {
-     .          .     15:		alloc()
-        */
-        /*
-            We only want the flat bytes, that's our definition of where the
-            allocation is. In the example above, the alloc() call on line 15
-            has no flat bytes, the first column. We want the actual allocation
-            on line 10, where the string is created.
-        */
-        /*
-            TODO all this logic can be better
-            We can use the -list argument below to ensure we only
-            see user code -- likely use the module name for that. This
-            would allow removing isUserCode.
-            Then, maybe the regex is too complicated, consider actual parsing.
-            Or maybe the regex is best!
-        */
-
-        const signal = this.abortSignal();
-
-        try {
-            // Check if operation was cancelled before parsing
-            if (signal.aborted) {
-                throw new Error('Operation cancelled');
-            }
-
-            // Use streaming approach for memory efficiency
-            const results = await new Promise<BenchmarkChildItem[]>((resolve, reject) => {
-                const items: BenchmarkChildItem[] = [];
-                let currentFunction = '';
-                let currentFile = '';
-                let inFunction = false;
-                let stderr = '';
-
-                const moduleName = benchmarkItem.parent.parent.moduleName;
-                const cmd = 'go';
-                const args = ['tool', 'pprof', `-list=${moduleName}`, memprofilePath];
-
-                const child = spawn(cmd, args, {
-                    cwd: benchmarkItem.filePath,
-                    signal,
-                    stdio: ['ignore', 'pipe', 'pipe']
-                });
-
-                const rl = readline.createInterface({
-                    input: child.stdout,
-                    crlfDelay: Infinity
-                });
-
-                // Capture stderr output
-                child.stderr?.on('data', (data) => {
-                    stderr += data.toString();
-                });
-
-                rl.on('line', (line) => {
-                    const trimmedLine = line.trim();
-
-                    // Check if this is a function header
-                    const functionMatch = trimmedLine.match(this.routineRegex);
-                    if (functionMatch) {
-                        currentFunction = functionMatch[1];
-                        currentFile = functionMatch[2];
-                        inFunction = true;
-                        return;
-                    }
-
-                    // Check if we're in a function and this is a line with allocation data
-                    if (inFunction && trimmedLine && !trimmedLine.includes('Total:') && !trimmedLine.includes('ROUTINE')) {
-                        const lineMatch = trimmedLine.match(this.lineRegex);
-                        if (lineMatch) {
-                            const flatBytes = lineMatch[1] || '0B';
-                            const cumulativeBytes = lineMatch[2] || '0B';
-                            const lineNumber = parseInt(lineMatch[3]);
-                            const codeLine = lineMatch[4];
-
-                            if (lineNumber > 0 && (flatBytes !== '0B' || cumulativeBytes !== '0B')) {
-                                const functionName = this.shortFunctionName(currentFunction);
-
-                                const allocationItem = new AllocationItem(
-                                    `${codeLine.trim()}`,
-                                    currentFile,
-                                    lineNumber,
-                                    {
-                                        flatBytes: flatBytes,
-                                        cumulativeBytes: cumulativeBytes,
-                                        functionName: functionName
-                                    }
-                                );
-                                items.push(allocationItem);
-                            }
-                        }
-                    }
-
-                    // Reset when we hit an empty line or new function
-                    if (trimmedLine === '' || trimmedLine.includes('ROUTINE')) {
-                        inFunction = false;
-                    }
-                });
-
-                rl.on('close', () => {
-                    resolve(items);
-                });
-
-                // Handle process spawn errors (e.g., command not found)
-                child.on('error', (error) => {
-                    reject(error);
-                });
-
-                child.on('close', (code) => {
-                    if (stderr.includes('no matches found for regexp')) {
-                        resolve([this.noAllocationsItem]);
-                        return;
-                    }
-
-                    // If process exited with non-zero code and we have stderr, treat as error
-                    if (code !== 0 && stderr.trim()) {
-                        reject(new Error(`pprof exit code ${code}: ${stderr.trim()}`));
-                        return;
-                    }
-
-                    // If we get here, the process completed successfully
-                    // The readline interface will handle resolving with the parsed items
-                });
-            });
-
-            // If no allocation data found, show a message
-            if (results.length === 0) {
-                results.push(this.noAllocationsItem);
-            }
-
-            return results;
-        } catch (error) {
-            console.error('Error parsing memory profile:', error);
-            const msg = error instanceof Error ? error.message : String(error);
-            return [
-                new InformationItem(
-                    `${msg}`,
-                    'error'
-                )
-            ];
-        }
     }
 
     /**

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -691,8 +691,8 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
                         if (signal.aborted) {
                             return;
                         }
-                        // Because TreeView.reveal is Thenable which doesn't have .catch,
-                        // we need to wrap in Promise.resolve.
+
+                        this.clearBenchmarkRunState(benchmarkItem);
                         const r = treeView.reveal(benchmarkItem, { expand: true });
                         await Promise.resolve(r);
                     } catch (error: any) {

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -410,8 +410,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
     private benchmarkItems: Map<string, BenchmarkItem> = new Map();
     private loadingPromise: Promise<void> | null = null;
 
-    // No secondary caches for TreeItems; use stable ids and ModuleCache as source of truth
-
     constructor() { }
 
     private abortController: AbortController = new AbortController();
@@ -449,12 +447,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
     }
 
     getParent(element: Item): vscode.ProviderResult<Item> {
-        // For our tree structure:
-        // - Root level has no parent (return undefined)
-        // - Package items have no parent (return undefined)
-        // - Benchmark functions have package as parent
-        // - Allocation lines have benchmark function as parent
-
         if (!element) {
             return undefined; // Root level
         }
@@ -464,7 +456,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         }
 
         if (element instanceof PackageItem) {
-            return element.parent; // Package's parent is its module
+            return element.parent;
         }
 
         if (element instanceof BenchmarkItem) {
@@ -472,9 +464,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         }
 
         if (element instanceof AllocationItem) {
-            // For allocation lines, we need to reconstruct the benchmark function
-            // This is tricky since we don't store the parent reference
-            // For now, return undefined - this might cause issues with reveal
             return undefined;
         }
 

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -27,6 +27,26 @@ export class InformationItem extends vscode.TreeItem {
     }
 }
 
+
+const getPackageLabel = (pkg: { name: string; path: string; benchmarks: string[] }): string => {
+    // Get the workspace folder that contains this package
+    const workspaceFolder = vscode.workspace.workspaceFolders?.find(folder =>
+        pkg.path.startsWith(folder.uri.fsPath)
+    );
+
+    if (workspaceFolder) {
+        const relativePath = path.relative(workspaceFolder.uri.fsPath, pkg.path);
+        // Use the package name when at the workspace root or when the
+        // relative path matches the package name; otherwise use the path.
+        if (relativePath === '' || relativePath === pkg.name) {
+            return pkg.name;
+        }
+        return relativePath;
+    }
+
+    return pkg.name;
+}
+
 export class ModuleItem extends vscode.TreeItem {
     public readonly moduleName: string;
     public readonly modulePath: string;
@@ -39,6 +59,26 @@ export class ModuleItem extends vscode.TreeItem {
         super(moduleName, vscode.TreeItemCollapsibleState.Expanded);
         this.moduleName = moduleName;
         this.modulePath = modulePath;
+    }
+
+    getChildren(modules: ModuleCache[]): PackageItem[] {
+        const module = modules.find(m => m.path === this.modulePath);
+        if (!module) {
+            throw new Error('Module not found in cache');
+        }
+
+        const packages: PackageItem[] = [];
+
+        for (const pkg of module.packages) {
+            const item = new PackageItem(
+                getPackageLabel(pkg),
+                pkg.path,
+                this
+            );
+            packages.push(item);
+        }
+
+        return packages;
     }
 }
 
@@ -384,25 +424,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         this.abortController = new AbortController();
     }
 
-    private getPackageLabel(pkg: { name: string; path: string; benchmarks: string[] }): string {
-        // Get the workspace folder that contains this package
-        const workspaceFolder = vscode.workspace.workspaceFolders?.find(folder =>
-            pkg.path.startsWith(folder.uri.fsPath)
-        );
-
-        if (workspaceFolder) {
-            const relativePath = path.relative(workspaceFolder.uri.fsPath, pkg.path);
-            // Use the package name when at the workspace root or when the
-            // relative path matches the package name; otherwise use the path.
-            if (relativePath === '' || relativePath === pkg.name) {
-                return pkg.name;
-            }
-            return relativePath;
-        }
-
-        return pkg.name;
-    }
-
     clearBenchmarkRunState(item: BenchmarkItem): void {
         this._onDidChangeTreeData.fire(item);
     }
@@ -482,7 +503,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         }
 
         if (element instanceof ModuleItem) {
-            return this.getPackagesForModule(element);
+            return element.getChildren(this.modules);
         }
 
         if (element instanceof PackageItem) {
@@ -663,26 +684,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
         }
 
         return relativePath.replaceAll('\\', '/');
-    }
-
-    private getPackagesForModule(moduleItem: ModuleItem): PackageItem[] {
-        const module = this.modules.find(m => m.path === moduleItem.modulePath);
-        if (!module) {
-            throw new Error('Module not found in cache');
-        }
-
-        const packages: PackageItem[] = [];
-
-        for (const pkg of module.packages) {
-            const item = new PackageItem(
-                this.getPackageLabel(pkg),
-                pkg.path,
-                moduleItem
-            );
-            packages.push(item);
-        }
-
-        return packages;
     }
 
     /**

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -673,7 +673,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
      * Discovers all benchmarks, and runs them with semaphore control.
      * Relies on TreeView.reveal to trigger getChildren automatically.
      */
-    async runAllBenchmarksSimple(treeView: vscode.TreeView<Item>): Promise<void> {
+    async runAllBenchmarks(treeView: vscode.TreeView<Item>): Promise<void> {
         const signal = this.abortSignal();
 
         const sema = new Sema(2);

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -27,7 +27,7 @@ export class InformationItem extends vscode.TreeItem {
     }
 }
 
-const getPackageLabel = (pkg: { name: string; path: string; benchmarkNames: string[] }): string => {
+const getPackageLabel = (pkg: PackageCache): string => {
     // Get the workspace folder that contains this package
     const workspaceFolder = vscode.workspace.workspaceFolders?.find(folder =>
         pkg.path.startsWith(folder.uri.fsPath)
@@ -402,10 +402,16 @@ class BenchmarkItemCache extends Map<string, BenchmarkItem> {
     }
 }
 
+interface PackageCache {
+    name: string;
+    path: string;
+    benchmarkNames: string[];
+}
+
 interface ModuleCache {
     name: string;
     path: string;
-    packages: { name: string; path: string; benchmarkNames: string[] }[]
+    packages: PackageCache[];
 }
 
 export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
@@ -621,7 +627,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
             console.log(`Found ${benchmarkSymbols.length} benchmark functions in ${workspaceFolder.name}`);
 
             // Group benchmarks by package directory
-            const packageMap = new Map<string, { name: string; path: string; benchmarkNames: string[] }>();
+            const packageMap = new Map<string, PackageCache>();
 
             for (const symbol of benchmarkSymbols) {
                 if (signal.aborted) {

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -27,7 +27,6 @@ export class InformationItem extends vscode.TreeItem {
     }
 }
 
-
 const getPackageLabel = (pkg: { name: string; path: string; benchmarks: string[] }): string => {
     // Get the workspace folder that contains this package
     const workspaceFolder = vscode.workspace.workspaceFolders?.find(folder =>
@@ -104,7 +103,7 @@ export class PackageItem extends vscode.TreeItem {
         this.tooltip = `Go package: ${label}\nPath: ${filePath}`;
     }
 
-    getChildren(modules: ModuleCache[], benchmarkItems: Map<string, BenchmarkItem>): BenchmarkItem[] {
+    getChildren(modules: ModuleCache[], benchmarkItems: BenchmarkItemCache): BenchmarkItem[] {
         // Find the package in the modules structure
         const module = modules.find(m => m.packages.some(p => p.path === this.filePath));
         if (!module) {
@@ -395,6 +394,8 @@ export interface AllocationData {
     functionName: string;
 }
 
+class BenchmarkItemCache extends Map<string, BenchmarkItem> { }
+
 interface ModuleCache {
     name: string;
     path: string;
@@ -407,7 +408,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
 
     // Cache for discovered modules and their packages
     private modules: ModuleCache[] = [];
-    private benchmarkItems: Map<string, BenchmarkItem> = new Map();
+    private benchmarkItems: BenchmarkItemCache = new BenchmarkItemCache();
     private loadingPromise: Promise<void> | null = null;
 
     constructor() { }


### PR DESCRIPTION
Many renames, encapsulations, file moves, new named types for clarity. Intended not to have functional changes.

Except one functional change: “run all benchmarks” now does a re-run of all benchmarks. Previously, it only ran those that hadn’t been run yet (i.e. didn’t clear state).