### PR TITLE
User preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,5 +33,5 @@ When I ask you to "review this PR", use the gh CLI tool to get information
 about the pull request, based on the current local git branch.
 
 When I ask you to publish your review summary to the PR, use the gh CLI tool
-to do so, and **clearly identify** who you are (Cursor), that this was an
+to do so, and **clearly identify** who you are (for example, VS Code Copilot, Cursor, etc), that this was an
 automated review, and what LLM model you are using.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,17 @@
                 }
             ]
         },
+        "configuration": {
+            "type": "object",
+            "title": "Go Allocations Explorer",
+            "properties": {
+                "goAllocations.showCodeLens": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show 'find allocations' code lens in benchmark functions"
+                }
+            }
+        },
         "commands": [
             {
                 "command": "goAllocations.runAllBenchmarks",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,13 @@
                 "goAllocations.showCodeLens": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Show 'find allocations' code lens in benchmark functions"
+                    "description": "Show 'find allocations' code lens on benchmark functions"
+                },
+                "goAllocations.concurrency": {
+                    "type": "number",
+                    "default": 2,
+                    "minimum": 1,
+                    "description": "Maximum number of benchmarks to run concurrently when using 'Run all benchmarks'"
                 }
             }
         },

--- a/src/codelens.ts
+++ b/src/codelens.ts
@@ -8,7 +8,19 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
 
     constructor() { }
 
+    refresh(): void {
+        this.onDidChangeCodeLensesEmitter.fire();
+    }
+
     provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
+        // Check if code lens is enabled in settings
+        const config = vscode.workspace.getConfiguration('goAllocations');
+        const showCodeLens = config.get<boolean>('showCodeLens', true);
+
+        if (!showCodeLens) {
+            return [];
+        }
+
         // Only add to _test.go files
         if (!document.fileName.endsWith('_test.go')) return [];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,11 +66,20 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(refresh);
 
     const codeLensFilter: DocumentFilter = { language: 'go', scheme: 'file', pattern: '**/*_test.go' };
+    const codeLensProvider = new CodeLensProvider();
     const codeLens = vscode.languages.registerCodeLensProvider(
         codeLensFilter,
-        new CodeLensProvider()
+        codeLensProvider
     );
     context.subscriptions.push(codeLens);
+
+    // Listen for configuration changes to refresh code lenses
+    const configChangeListener = vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration('goAllocations.showCodeLens')) {
+            codeLensProvider.refresh();
+        }
+    });
+    context.subscriptions.push(configChangeListener);
 
     // Command invoked by CodeLens in editor to run a specific benchmark
     const runBenchmarkFromEditor = vscode.commands.registerCommand(

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -724,7 +724,11 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
     async runAllBenchmarks(treeView: vscode.TreeView<Item>): Promise<void> {
         const signal = this.abortSignal();
 
-        const sema = new Sema(2);
+        // Get concurrency setting from configuration
+        const config = vscode.workspace.getConfiguration('goAllocations');
+        const concurrency = config.get<number>('concurrency', 2);
+
+        const sema = new Sema(concurrency);
         const promises: Promise<void>[] = [];
 
         try {

--- a/src/treedata.ts
+++ b/src/treedata.ts
@@ -726,7 +726,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<Item> {
 
         // Get concurrency setting from configuration
         const config = vscode.workspace.getConfiguration('goAllocations');
-        const concurrency = config.get<number>('concurrency', 2);
+        const concurrency = Math.max(1, Math.floor(config.get<number>('concurrency', 2)));
 
         const sema = new Sema(concurrency);
         const promises: Promise<void>[] = [];


### PR DESCRIPTION
 Allow user to control whether to display the “find allocations” code lens

Allow user setting of concurrency on “run all benchmarks” 